### PR TITLE
Fix Typo link to file config.rb in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ These are the currently-supported gems and their symbolized names:
 | [PgSearch]   | `:pg_search`   |
 | [FriendlyId] | `:friendly_id` |
 
-You can also configure the core model plugins if needed. The default plugins are defined in the [config](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/lib/sorbet-rails/config.rb). For the full list of plugin symbols, check out [here](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/model_plugins/plugins.rb).
+You can also configure the core model plugins if needed. The default plugins are defined in the [config](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/config.rb). For the full list of plugin symbols, check out [here](https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/model_plugins/plugins.rb).
 
 
 [Kaminari]: https://github.com/kaminari/kaminari


### PR DESCRIPTION
The typo is :
- before : https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/lib/sorbet-rails/config.rb 
- should be : https://github.com/chanzuckerberg/sorbet-rails/blob/master/lib/sorbet-rails/config.rb